### PR TITLE
Minor fixes

### DIFF
--- a/playbooks/configure_latency_tests.yaml
+++ b/playbooks/configure_latency_tests.yaml
@@ -35,7 +35,7 @@
         shell:
           cmd: >-
             echo 0 > /proc/sys/kernel/kptr_restrict
-
+        when: enable_svtrace is defined and enable_svtrace|bool == true
 - name: Configure svtrace
   become: true
   hosts:
@@ -55,3 +55,4 @@
         shell:
           cmd: >-
             echo 0 > /proc/sys/kernel/kptr_restrict
+        when: enable_svtrace is defined and enable_svtrace|bool == true

--- a/playbooks/configure_latency_tests.yaml
+++ b/playbooks/configure_latency_tests.yaml
@@ -6,6 +6,9 @@
   hosts:
     - localhost
   tasks:
+    - name: Build_sv_timestamp_analysis
+      include_role:
+        name: "build_sv_timestamp_analysis"
     - name: Build sv_timestamp_logger for each subscriber
       include_role:
         name: "build_sv_timestamp_logger"

--- a/playbooks/run_latency_tests.yaml
+++ b/playbooks/run_latency_tests.yaml
@@ -61,9 +61,6 @@
   hosts:
     localhost
   tasks:
-    - name: Build_sv_timestamp_analysis
-      include_role:
-        name: "build_sv_timestamp_analysis"
     - name: Generate sv_timestamp_results
       include_role:
         name: "generate_sv_timestamp_results"


### PR DESCRIPTION
Hello,
This PR adds some minor fixes to svtrace-ansible:
* Build of the sv_timestamp_analysis in configure_latency_tests playbook instead of run_latency_tests playbook
* Disable kptr restriction only if svtrace is used