### PR TITLE
Fix svtrace.py --machine "hypervisor" argument

### DIFF
--- a/roles/run_svtrace/tasks/main.yaml
+++ b/roles/run_svtrace/tasks/main.yaml
@@ -4,7 +4,7 @@
 - name : Run svtrace
   shell:
     cmd: >-
-      taskset -c {{ svtrace_core }} svtrace.py --record --conf /etc/svtrace.cfg --machine {{ group_names[0] }}
+      taskset -c {{ svtrace_core }} svtrace.py --record --conf /etc/svtrace.cfg --machine {{ "hypervisor" if group_names[0] == "hypervisors" else group_names[0] }}
   async: 9999999
   poll: 0
   register: svtrace_status


### PR DESCRIPTION
svtrace.py --machine expects hypervisor or VM but the inventory group name is hypervisors (plural).

Add an ad-hoc filter to adapt group_name to svtrace.py syntax.