### PR TITLE
Cleanups around pcap_* vars

### DIFF
--- a/inventories/common.yaml
+++ b/inventories/common.yaml
@@ -51,10 +51,10 @@ all:
 
                             sv_interface: # SV reception interface
 
+                            pcap_file: # PCAP file to be used (absolute path)
                             pcap_cycles: 10 # Number of PCAP loops to repeat
                             sv_ts_core: # sv_timestamp_logger CPU core
                             enable_sv_ts: # Enable sv_timestamp_logger
-                            pcap_file: # Path of the PCAP file to be used
                             bittwist_core: # bittwist CPU core
                             ptp_manual_configuration: # Set to false to disable ptp configuration
                             first_SV: # First SV counter defined in PCAP file

--- a/playbooks/run_latency_tests.yaml
+++ b/playbooks/run_latency_tests.yaml
@@ -46,7 +46,7 @@
     publisher
   tasks:
       - name: Send SV
-        command: chrt --fifo 1 taskset -c {{ bittwist_core }} bittwist -i {{ sv_interface }} {{ pcap_path }}{{ pcap_file }} -l {{ pcap_loop }}
+        command: chrt --fifo 1 taskset -c {{ bittwist_core }} bittwist -i {{ sv_interface }} {{ pcap_path }}{{ pcap_file }} -l {{ pcap_cycles }}
 
 - name: End test
   hosts:

--- a/playbooks/run_latency_tests.yaml
+++ b/playbooks/run_latency_tests.yaml
@@ -46,7 +46,7 @@
     publisher
   tasks:
       - name: Send SV
-        command: chrt --fifo 1 taskset -c {{ bittwist_core }} bittwist -i {{ sv_interface }} {{ pcap_path }}{{ pcap_file }} -l {{ pcap_cycles }}
+        command: chrt --fifo 1 taskset -c {{ bittwist_core }} bittwist -i {{ sv_interface }} {{ pcap_file }} -l {{ pcap_cycles }}
 
 - name: End test
   hosts:


### PR DESCRIPTION
- run_latency_tests: Fix pcap_cycles usage:
  > pcap_cycles is used instead of pcap_loop (in scripts, inventory, and README)
- Remove unneeded and undocumented pcap_path variable:
  > Instead, pcap_file can be an absolute path. No need for 2 variables that
  > are always concatenated when used.
  > 
  > Update inventory to put the variable pcap_file around the other pcap
  > variable. And update comment to specify that this must be an absolute
  > path.