### PR TITLE
build_svtrace: add svtrace.cfg.j2 to template

### DIFF
--- a/roles/build_svtrace/tasks/main.yaml
+++ b/roles/build_svtrace/tasks/main.yaml
@@ -8,6 +8,6 @@
   when: enable_svtrace is defined and enable_svtrace|bool == true
 - name: Send svtrace configuration file
   template:
-      src: ../files/templates/svtrace.cfg.j2
+      src: svtrace.cfg.j2
       dest: /etc/svtrace.cfg
   when: enable_svtrace is defined and enable_svtrace|bool == true

--- a/roles/build_svtrace/templates/svtrace.cfg.j2
+++ b/roles/build_svtrace/templates/svtrace.cfg.j2
@@ -1,0 +1,3 @@
+[DEFAULT]
+SV_INTERFACE={{ sv_interface }}
+SV_BUFFER_SIZE=100000


### PR DESCRIPTION
The current role pointed to a non existing file and caused playbook failure.