### PR TITLE
generate_sv_timestamp_results: Use stream_to_log inventory variable

### DIFF
--- a/roles/generate_sv_timestamp_results/tasks/main.yaml
+++ b/roles/generate_sv_timestamp_results/tasks/main.yaml
@@ -11,7 +11,7 @@
           --sub "../tests_results/data/ts_{{ hostvars[item].inventory_hostname }}.txt" \
           --pub "../tests_results/data/ts_{{ publisher_name }}.txt" \
           --subscriber_name "{{ hostvars[item].inventory_hostname }}" \
-          --stream "0" \
+          --stream {{ stream_to_log }} \
           --max_latency {{ hostvars[item]['max_latency'] | default(max_latency) }} \
           --display_max_latency \
           -o "../tests_results/data/ci_latency_tests_{{ hostvars[item].inventory_hostname }}/"


### PR DESCRIPTION
With seapath/sv-timestamp-analysis@6dc9202ec45f, we can now
use the SVID from inventory instead of hard-coding "0" (aka first stream available)

TODO:
- [x] Change PR ref to merge commit once merged.

> [!NOTE]  
> This PR depends on seapath/sv-timestamp-analysis#9 (now merged)