### PR TITLE
svtrace: deploy/run in a virtual env

### DIFF
--- a/inventories/common.yaml
+++ b/inventories/common.yaml
@@ -6,6 +6,7 @@ all:
     vars:
       first_SV: # First SV counter defined in PCAP file
       stream_to_log: # Desired SV stream to record. If not set, all streams are logged.
+      svtrace_venv_path: /tmp/svtrace_venv/
     children:
         standalone_machine:
             children:

--- a/roles/build_svtrace/tasks/main.yaml
+++ b/roles/build_svtrace/tasks/main.yaml
@@ -3,8 +3,9 @@
 ---
 - name: Install svtrace
   ansible.builtin.pip:
+    virtualenv: "{{ svtrace_venv_path }}"
+    virtualenv_command: "{{ ansible_python_interpreter }} -m venv "
     name: git+https://github.com/seapath/svtrace.git@v0.1.1
-    extra_args: --break-system-packages
   when: enable_svtrace is defined and enable_svtrace|bool == true
 - name: Send svtrace configuration file
   template:

--- a/roles/run_svtrace/tasks/main.yaml
+++ b/roles/run_svtrace/tasks/main.yaml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ---
 - name : Run svtrace
-  shell:
-    cmd: >-
-      taskset -c {{ svtrace_core }} svtrace.py --record --conf /etc/svtrace.cfg --machine {{ "hypervisor" if group_names[0] == "hypervisors" else group_names[0] }}
+  shell: |
+    . {{ svtrace_venv_path }}/bin/activate
+    taskset -c {{ svtrace_core }} svtrace.py --record --conf /etc/svtrace.cfg --machine {{ "hypervisor" if group_names[0] == "hypervisors" else group_names[0] }}
   async: 9999999
   poll: 0
   register: svtrace_status


### PR DESCRIPTION
Using a virtualenv to install svtrace allows:
* to control exactly where svtrace is installed (even as a non-root user)
* to easily cleanup after the test (That remain to be done)

Ref: https://virtualenv.pypa.io/en/latest/

Fixes seapath/svtrace-ansible#9.