### PR TITLE
end_sv_timestamp_logger: save sv_drops by host

### DIFF
--- a/roles/end_sv_timestamp_logger/tasks/main.yaml
+++ b/roles/end_sv_timestamp_logger/tasks/main.yaml
@@ -22,7 +22,7 @@
 - name: Fetch sv drop
   synchronize:
     src: /tmp/sv_drops
-    dest: ../tests_results/data/
+    dest: ../tests_results/data/sv_drops_{{ inventory_hostname }}
     mode: pull
 - name: Fetch SV timestamps
   synchronize:


### PR DESCRIPTION
Saving sv_drops by host may help identify the localisation of the drop
(before/after the hypervisor).

Each sv_drops file will be save as "tests_results/data/sv_drops_{{ inventory_hostname }}".

Also, in rare cases, the "Fetch sv drop" synchronize task fails with:
```
    rsync: [receiver] rename failed for "[...]/tests_results/data/sv_drops" (from .~tmp~/sv_drops): No such file or directory (2)
    rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1865) [generator=3.2.7]
```
It looks like a race condition between the rsync from different hosts.
Saving by host will also prevent that.