### PR TITLE
Dockerfile: install community.docker 4.8.7

### DIFF
--- a/.cqfd/docker/Dockerfile
+++ b/.cqfd/docker/Dockerfile
@@ -46,3 +46,5 @@ RUN sed -i "s/# en_US\.UTF-8 UTF-8/en_US\.UTF-8 UTF-8/" /etc/locale.gen
 RUN locale-gen
 RUN dpkg-reconfigure locales
 ADD check_yaml.sh /usr/bin/check_yaml
+
+RUN ansible-galaxy collection install community.docker:==4.8.7 -p /usr/share/ansible/collections


### PR DESCRIPTION
Install community.docker version 4.8.7 to fix an issue when deploying sv_timestamp_logger with a wrynose VM. The version brought by ansible is 3.7.0, this version has an issue when the VM uses a version of python3-requests higher than 2.32.0.
This isn't problematic for scarthgap because it uses the 2.31.0 version but wrynose uses the 2.32.5.

The 4.8.7 version was chosen because it is the latest available for ansible 2.16.

The issue :
https://github.com/ansible-collections/community.docker/issues/860