### PR TITLE
roles: sv_timestamp_logger: force import of docker image

### DIFF
--- a/roles/build_sv_timestamp_logger/tasks/main.yaml
+++ b/roles/build_sv_timestamp_logger/tasks/main.yaml
@@ -15,4 +15,5 @@
       platform: "linux/{{ target_architecture }}"
     name: localhost/sv_timestamp_logger_{{ target_architecture }}
     archive_path: /tmp/sv_timestamp_logger_{{ target_architecture }}.tar
+    force_source: true
     source: build

--- a/roles/deploy_sv_timestamp_logger/tasks/main.yaml
+++ b/roles/deploy_sv_timestamp_logger/tasks/main.yaml
@@ -14,4 +14,5 @@
   docker_image:
     name: localhost/sv_timestamp_logger_{{ target_architecture }}
     load_path: /tmp/sv_timestamp_logger_{{ target_architecture }}.tar
+    force_source: true
     source: load


### PR DESCRIPTION
Without the "force_source" option, if the docker image to be built or imported already exists on the system, i.e. an image with the same name exists, then the "docker_image" task doesn't do anything.

This can lead to svtrace-ansible unexpectedly using old versions of sv_timestamp_logger that already exist on the ansible host and the target machines. This old images may be incompatible with the lastet version of sv-timestamp-analysis from the main branch.

Therefore, add the "force_source" option to assure the roles build and load the expected image.