### PR TITLE
Changes for arm64 test without publisher

### DIFF
--- a/inventories/common.yaml
+++ b/inventories/common.yaml
@@ -60,3 +60,11 @@ all:
                             pcap_cycles: 10 # Number of PCAP loops to repeat
                             enable_sv_ts: # Enable sv_timestamp_logger
                             bittwist_core: # bittwist CPU cored
+
+                reference_logger:
+                    hosts:
+                    # Add a host with hardware timestamping capability to use as
+                    # reference instead of the publisher.
+                    # The host can be one of the subscribers to measure the
+                    # userspace processing delay.
+                        # vm_name:

--- a/inventories/common.yaml
+++ b/inventories/common.yaml
@@ -7,6 +7,9 @@ all:
       first_SV: # First SV counter defined in PCAP file
       stream_to_log: # Desired SV stream to record. If not set, all streams are logged.
       svtrace_venv_path: /tmp/svtrace_venv/
+      # The duration to let the tests run when no publisher
+      # is found (external SV publisher) in minutes
+      test_duration: 10
     children:
         standalone_machine:
             children:

--- a/playbooks/configure_latency_tests.yaml
+++ b/playbooks/configure_latency_tests.yaml
@@ -20,6 +20,7 @@
   hosts:
     - publisher
     - subscriber
+    - reference_logger
   tasks:
     - name: Deploy sv_timestamp_logger
       include_role:

--- a/playbooks/run_latency_tests.yaml
+++ b/playbooks/run_latency_tests.yaml
@@ -41,6 +41,17 @@
       include_role:
         name: "run_sv_timestamp_logger"
 
+- name: Run hardware-timestamping reference logger
+  hosts:
+    - reference_logger
+  tasks:
+    - name: Gather ansible_user_dir fact
+      setup:
+        filter: ansible_user_dir
+    - name: Run sv_timestamp_logger_hw
+      include_role:
+        name: "run_sv_timestamp_logger_hw"
+
 - name: Start test
   hosts:
     publisher
@@ -66,6 +77,15 @@
     - name: End sv_timestamp_logger
       include_role:
         name: "end_sv_timestamp_logger"
+
+- name: End hardware-timestamping reference logger
+  hosts:
+    - reference_logger
+  tasks:
+    - name: End sv_timestamp_logger_hw
+      include_role:
+        name: "end_sv_timestamp_logger_hw"
+
 - name: Compute results
   hosts:
     localhost

--- a/playbooks/run_latency_tests.yaml
+++ b/playbooks/run_latency_tests.yaml
@@ -48,6 +48,15 @@
       - name: Send SV
         command: chrt --fifo 1 taskset -c {{ bittwist_core }} bittwist -i {{ sv_interface }} {{ pcap_file }} -l {{ pcap_cycles }}
 
+- name: Start test
+  hosts:
+    - localhost
+  tasks:
+    - name: Wait for test to end
+      ansible.builtin.pause:
+        minutes: "{{ test_duration | default(1)}}"
+      when: groups["publisher"] | length == 0
+
 - name: End test
   hosts:
     - publisher

--- a/roles/build_sv_timestamp_logger/tasks/main.yaml
+++ b/roles/build_sv_timestamp_logger/tasks/main.yaml
@@ -9,11 +9,12 @@
     repo: https://github.com/seapath/sv_timestamp_logger
     dest: /tmp/sv_timestamp_logger
 - name: Build sv_timestamp_logger
-  docker_image:
-    build:
-      path: /tmp/sv_timestamp_logger/
-      platform: "linux/{{ target_architecture }}"
+  community.docker.docker_image_build:
+    path: /tmp/sv_timestamp_logger/
+    platform: "linux/{{ target_architecture }}"
     name: localhost/sv_timestamp_logger_{{ target_architecture }}
-    archive_path: /tmp/sv_timestamp_logger_{{ target_architecture }}.tar
-    force_source: true
-    source: build
+    rebuild: "always"
+- name: Export sv_timestamp_logger
+  community.docker.docker_image_export:
+    name: localhost/sv_timestamp_logger_{{ target_architecture }}
+    path: /tmp/sv_timestamp_logger_{{ target_architecture }}.tar

--- a/roles/end_sv_timestamp_logger_hw/defaults/main.yaml
+++ b/roles/end_sv_timestamp_logger_hw/defaults/main.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+target_platform: amd64 # Overwritten by the target inventory

--- a/roles/end_sv_timestamp_logger_hw/tasks/main.yaml
+++ b/roles/end_sv_timestamp_logger_hw/tasks/main.yaml
@@ -1,0 +1,18 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: set platform
+  set_fact:
+    target_architecture: "{{ hostvars[inventory_hostname]['target_platform'] | default(target_platform) }}"
+
+- name: Stop hardware sv_timestamp_logger container
+  become: true
+  docker_container:
+    name: sv_timestamp_logger_hw_{{ target_architecture }}
+    state: absent
+
+- name: Fetch hardware SV timestamps
+  synchronize:
+    src: "{{ ansible_user_dir }}/latency_tests/ts_hw_{{ inventory_hostname }}.txt"
+    dest: ../tests_results/data/
+    mode: pull

--- a/roles/generate_sv_timestamp_results/tasks/main.yaml
+++ b/roles/generate_sv_timestamp_results/tasks/main.yaml
@@ -4,12 +4,23 @@
 - name: Get publisher hostname
   set_fact:
     publisher_name: "{{ hostvars[groups['publisher'][0]].inventory_hostname }}"
-- name: Generate SV results
+  when: groups["publisher"] | length > 0
+
+- name: Get reference logger hostname
+  set_fact:
+    reference_logger_name: "{{ hostvars[groups['reference_logger'][0]].inventory_hostname }}"
+  when: groups["reference_logger"] | length > 0
+
+- name: Generate SV results with publisher as reference
   shell:
     cmd: >-
         python3 ../sv-timestamp-analysis/sv_timestamp_analysis.py \
           --sub "../tests_results/data/ts_{{ hostvars[item].inventory_hostname }}.txt" \
+          {% if reference_logger_name is defined %}
+          --pub "../tests_results/data/ts_hw_{{ reference_logger_name }}.txt" \
+          {% else %}
           --pub "../tests_results/data/ts_{{ publisher_name }}.txt" \
+          {% endif %}
           --subscriber_name "{{ hostvars[item].inventory_hostname }}" \
           --stream {{ stream_to_log }} \
           --max_latency {{ hostvars[item]['max_latency'] | default(max_latency) }} \

--- a/roles/run_sv_timestamp_logger_hw/defaults/main.yaml
+++ b/roles/run_sv_timestamp_logger_hw/defaults/main.yaml
@@ -1,0 +1,4 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+target_platform: amd64 # Overwritten by the target inventory

--- a/roles/run_sv_timestamp_logger_hw/tasks/main.yaml
+++ b/roles/run_sv_timestamp_logger_hw/tasks/main.yaml
@@ -1,0 +1,34 @@
+# Copyright (C) 2025 Savoir-faire Linux, Inc.
+# SPDX-License-Identifier: Apache-2.0
+---
+- name: set platform
+  set_fact:
+    target_architecture: "{{ hostvars[inventory_hostname]['target_platform'] | default(target_platform) }}"
+
+- name: Stop hardware sv_timestamp_logger container
+  become: true
+  docker_container:
+    name: sv_timestamp_logger_hw_{{ target_architecture }}
+    state: absent
+
+- name: Run hardware-timestamping SV timestamp logger container
+  become: true
+  docker_container:
+    name: sv_timestamp_logger_hw_{{ target_architecture }}
+    image: sv_timestamp_logger_{{ target_architecture }}
+    state: started
+    detach: true
+    privileged: true
+    volumes:
+      - "{{ ansible_user_dir }}/latency_tests:/tmp/latency_tests"
+    devices:
+      - "/dev/ptp0:/dev/ptp0"
+    network_mode: host
+    capabilities:
+      - NET_ADMIN
+      - SYS_NICE
+    command: >
+      -d {{ sv_interface }}
+      -f "/tmp/latency_tests/ts_hw_{{ inventory_hostname }}.txt"
+      -s {{ stream_to_log }}
+      -t


### PR DESCRIPTION
This fixes some problems with using svtrace-ansible to launch tests on  a arm64 machine.

The build of sv_timestamp_logger docker image failed when using the linux/arm64 platform. This was caused by the docker_image module, as it uses the legacy build system of Docker. 
This causes an error that is not present when using the Buildkit build system of Docker. The fix is thus to use the Buildkit build system, this is done by replacing the docker_image module to docker_image_build and docker_image_export modules.

Changes :
- Fixes building sv_timestamp_logger for arm64 machines.
- Adds a way to launch the tests without a publisher managed by Ansible. By adding a test_duration to wait for the tests to finish.
- Adds reference_logger group to use as reference when the publisher is not capable of using sv_timestamp_logger, the host in the reference_logger group uses hardware timestamping to serve as a reference 
