### PR TITLE
Add more options to launch sv_timestamp_logger

### DIFF
--- a/inventories/common.yaml
+++ b/inventories/common.yaml
@@ -32,6 +32,7 @@ all:
                             enable_svtrace: # Enable svtrace tracing
                             svtrace_core: # Core to run svtrace (should be isolated)
                             enable_sv_ts: # Enable sv_timestamp_logger
+                            sv_ts_core: # sv_timestamp_logger CPU core
 
                 publisher:
                     hosts:
@@ -59,6 +60,7 @@ all:
                             pcap_file: # PCAP file to be used (absolute path)
                             pcap_cycles: 10 # Number of PCAP loops to repeat
                             enable_sv_ts: # Enable sv_timestamp_logger
+                            sv_ts_core: # sv_timestamp_logger CPU core
                             bittwist_core: # bittwist CPU cored
 
                 reference_logger:
@@ -68,3 +70,4 @@ all:
                     # The host can be one of the subscribers to measure the
                     # userspace processing delay.
                         # vm_name:
+                            # hw_ts_core: # sv_timestamp_logger_hw CPU core

--- a/roles/run_sv_timestamp_logger/tasks/main.yaml
+++ b/roles/run_sv_timestamp_logger/tasks/main.yaml
@@ -21,6 +21,7 @@
     cpuset_cpus: "{{ sv_ts_core if (sv_ts_core is defined and not sv_ts_core is none) else omit }}"
     volumes:
       - "{{ ansible_user_dir }}/latency_tests:/tmp/latency_tests"
+    devices: "{{ [clock_device ~ ':' ~ clock_device] if (clock_device is defined and clock_device | length > 0) else omit }}"
     network_mode: host
     capabilities:
       - NET_ADMIN
@@ -32,4 +33,5 @@
       {% if 'publisher' in group_names %}
       -t
       {% endif %}
+      {{ ('--clock_device ' ~ clock_device) if (clock_device is defined and clock_device | length > 0) else '' }}
   when: enable_sv_ts is defined and enable_sv_ts|bool == true

--- a/roles/run_sv_timestamp_logger/tasks/main.yaml
+++ b/roles/run_sv_timestamp_logger/tasks/main.yaml
@@ -18,6 +18,7 @@
     state: started
     detach: true
     privileged: true
+    cpuset_cpus: "{{ sv_ts_core if (sv_ts_core is defined and not sv_ts_core is none) else omit }}"
     volumes:
       - "{{ ansible_user_dir }}/latency_tests:/tmp/latency_tests"
     network_mode: host

--- a/roles/run_sv_timestamp_logger_hw/tasks/main.yaml
+++ b/roles/run_sv_timestamp_logger_hw/tasks/main.yaml
@@ -19,6 +19,7 @@
     state: started
     detach: true
     privileged: true
+    cpuset_cpus: "{{ hw_ts_core if (hw_ts_core is defined and not hw_ts_core is none) else omit }}"
     volumes:
       - "{{ ansible_user_dir }}/latency_tests:/tmp/latency_tests"
     devices:


### PR DESCRIPTION
Add three variables to use in inventories :
- sv_ts_core, to pin sv_timestamp_logger instances to specific CPU core.
- hw_ts_core, to pin hardware timestamped reference logger to specific CPU core.
- clock_device, to allow reading userspace timestamp from NIC PHC instead of CLOCK_REALTIME