### PR TITLE
generate_sv_timestamps_results: make reference_logger group optional

### DIFF
--- a/roles/generate_sv_timestamp_results/tasks/main.yaml
+++ b/roles/generate_sv_timestamp_results/tasks/main.yaml
@@ -9,7 +9,7 @@
 - name: Get reference logger hostname
   set_fact:
     reference_logger_name: "{{ hostvars[groups['reference_logger'][0]].inventory_hostname }}"
-  when: groups["reference_logger"] | length > 0
+  when: groups["reference_logger"] is defined and groups["reference_logger"] | length > 0
 
 - name: Generate SV results with publisher as reference
   shell:


### PR DESCRIPTION
Skip Get reference logger hostname task when reference_logger group is not defined.  
This allows the reference_logger group to be optional.