### PR TITLE
run_sv_timestamp_logger_hw: specify "localhost" registry for image

### DIFF
--- a/roles/run_sv_timestamp_logger_hw/tasks/main.yaml
+++ b/roles/run_sv_timestamp_logger_hw/tasks/main.yaml
@@ -15,7 +15,7 @@
   become: true
   docker_container:
     name: sv_timestamp_logger_hw_{{ target_architecture }}
-    image: sv_timestamp_logger_{{ target_architecture }}
+    image: localhost/sv_timestamp_logger_{{ target_architecture }}
     state: started
     detach: true
     privileged: true


### PR DESCRIPTION
Specify the "localhost" registry for the image.

Without this podman searches the image in the docker.io registry, thus failing to find it.